### PR TITLE
Enable priority class definition to enable preemption of the pod

### DIFF
--- a/fahclient/README.md
+++ b/fahclient/README.md
@@ -55,6 +55,7 @@ drop me an e-mail at <serge@se-cured.org>.
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | podSecurityContext.fsGroup | int | `9999` |  |
+| priorityClassName | string | `nil` | When not specified, take the default priority class |
 | replicaCount | int | `1` |  |
 | resources.limits.cpu | float | `1` |  |
 | resources.limits.memory | string | `"256Mi"` |  |

--- a/fahclient/templates/statefulset.yaml
+++ b/fahclient/templates/statefulset.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         app: {{ include "fahclient.fullname" . }}
     spec:
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       terminationGracePeriodSeconds: 10
       initContainers:
       - name: init


### PR DESCRIPTION
Updating the stateful set to include a priorityClassName, which enables defining the pod priority compared to other workloads.
This can be used to ensure FAH is given priority over other workloads, or to give it lower priority.

Consider this scenario:

A global default priority of 100
```
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: default-priority
value: 100
globalDefault: true
description: "This priority class is the default for the cluster"
```

A Priority Class with priority 10
```
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: low-priority
value: 10
globalDefault: false
description: "This priority class is for pods which should be preempted by all others"
```

If upon chart deploy I specify `priorityClassName: low-priority` then FAH pod(s) will be terminated any time a new pod is scheduled and the sum of all pods on the scheduled node results in resource pressure.
The FAH pods will automatically be re-scheduled, and execute again once the cluster is back to a more "idle" state.