### PR TITLE
Adding a pre stop hook to tell FAHClient that it's shutting down.  

### DIFF
--- a/fahclient/templates/statefulset.yaml
+++ b/fahclient/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 45
       initContainers:
       - name: init
         image: alpine:latest
@@ -38,6 +38,10 @@ spec:
             value: {{ .Values.securityContext.runAsUser | quote }}
           - name: PGID
             value: {{ .Values.securityContext.runAsGroup | quote }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["FAHClient", "--send-command", "shutdown"]
         ports:
         - containerPort: 7396
           name: http

--- a/fahclient/values.yaml
+++ b/fahclient/values.yaml
@@ -67,6 +67,10 @@ securityContext:
   runAsUser: 9999
   runAsGroup: 9999
 
+service:
+  type: ClusterIP
+  port: 80
+
 storageClassName: ""
 
 # set to some sane defaults to prevent interference


### PR DESCRIPTION
This allows for the workload to stop at an interval, which allows it to be resumed if restarted before the workload times out.

Increased the termination grace period to allow the process to finis the interval.

Added back the service definition, as the test-connection.yaml test was failing with it removed.