### PR TITLE
fix config.xml location, read me. image to latest

### DIFF
--- a/fahclient/Chart.yaml
+++ b/fahclient/Chart.yaml
@@ -14,4 +14,4 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 2.5.2
+version: 2.5.3

--- a/fahclient/README.md
+++ b/fahclient/README.md
@@ -44,8 +44,8 @@ drop me an e-mail at <serge@se-cured.org>.
 | horizontalPodAutoscaling.minReplicas | int | `1` |  |
 | horizontalPodAutoscaling.targetCPUUtilizationPercentage | int | `90` |  |
 | storageClassName | string | `""` | When not specified take the default storage class |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"johnktims/folding-at-home"` |  |
+| image.pullPolicy | string | `"Always"` |  |
+| image.repository | string | `"foldingathome/fah-gpu"` |  |
 | image.tag | string | `"latest"` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/fahclient/templates/statefulset.yaml
+++ b/fahclient/templates/statefulset.yaml
@@ -26,7 +26,13 @@ spec:
       initContainers:
       - name: init
         image: alpine:latest
-        command: ['sh', '-c', "mkdir -p /fah && chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} /fah"]
+        command: ['sh', '-c', "mkdir -p /fah && cp -f /tmp/fahclient/config.xml /fah/config.xml && chown -R {{ .Values.securityContext.runAsUser }}:{{ .Values.securityContext.runAsGroup }} /fah"]
+        volumeMounts:
+          - name: fah
+            mountPath: /fah
+          - name: fahclient-config
+            mountPath: /tmp/fahclient/config.xml
+            subPath: config.xml
       containers:
       - name: {{ .Chart.Name }}
         securityContext:
@@ -48,9 +54,6 @@ spec:
         volumeMounts:
         - name: fah
           mountPath: /fah
-        - name: fahclient-config
-          mountPath: /etc/fahclient/config.xml
-          subPath: config.xml
         resources:
           {{- if .Values.fahClient.gpu.enabled }}
             limits:

--- a/fahclient/values.yaml
+++ b/fahclient/values.yaml
@@ -6,8 +6,8 @@ replicaCount: 1
 
 image:
   repository: foldingathome/fah-gpu
-  tag: 7.5.1
-  pullPolicy: IfNotPresent
+  tag: latest
+  pullPolicy: Always
 
 # to use Vertical Pod Autoscaling install:
 # https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
@@ -29,20 +29,20 @@ fahClient:
     accelerator: nvidia-tesla-p100 # or nvidia-tesla-k80 etc.
   configXml: |
     <config>
-    <!-- Set with your user, passkey, team-->
-    <user value="Anonymous"/>
-    <passkey value=""/>
-    <team value="0"/>
-  
-    <power value="full"/>
-  
-    <web-enable v='false'/>
-    <disable-viz v='true'/>
-    <gui-enabled v='false'/>
-    <!-- 1 slots for GPUs -->
-    <!-- beta feature: uncomment the statement below if you have set
-    fahClient.gpu.enabled to true -->
-    <!-- <slot id='0' type='GPU'> </slot> -->
+      <!-- Set with your user, passkey, team-->
+      <user value="Anonymous"/>
+      <passkey value=""/>
+      <team value="0"/>
+
+      <power value="full"/>
+
+      <web-enable v='false'/>
+      <disable-viz v='true'/>
+      <gui-enabled v='false'/>
+      <!-- 1 slots for GPUs -->
+      <!-- beta feature: uncomment the statement below if you have set
+      fahClient.gpu.enabled to true -->
+      <!-- <slot id='0' type='GPU'> </slot> -->
     </config>
 
 imagePullSecrets: []


### PR DESCRIPTION
Likely due to image change to the official one but the official one expects the config.xml to be in the `fah/` working directory.
Also fixed your README.md to match the official image repo in values. I also changed it to always use latest image but let me know if you want me to remove this always latest change.

Start up logs before my change:
```
00:56:03:***********************************************************************
00:56:03:<config>
00:56:03:  <!-- Folding Slots -->
00:56:03:  <slot id='0' type='CPU'/>
00:56:03:</config>
00:56:03:WU01:FS00:Starting
```

After my change:
```
01:15:45:***********************************************************************
01:15:45:<config>
01:15:45:  <!-- Folding Slot Configuration -->
01:15:45:  <disable-viz v='true'/>
01:15:45:
01:15:45:  <!-- GUI -->
01:15:45:  <gui-enabled v='false'/>
01:15:45:
01:15:45:  <!-- Slot Control -->
01:15:45:  <power v='full'/>
01:15:45:
01:15:45:  <!-- User Information -->
01:15:45:  <passkey v='*****'/>
01:15:45:  <team v='******'/>
01:15:45:  <user v='******'/>
01:15:45:
01:15:45:  <!-- Web Server -->
01:15:45:  <web-enable v='false'/>
01:15:45:
01:15:45:  <!-- Folding Slots -->
01:15:45:  <slot id='0' type='CPU'/>
01:15:45:</config>
01:15:45:WU01:FS00:Starting
```

This change means if user changes only the config, it will not be reflected in running pods. They will need delete/recreate the pod so the init container can copy over the new config.

Signed-off-by: Dennis Zhang <dennis.zhang.nrg@gmail.com>